### PR TITLE
Remove invalid reference link from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,13 +6,13 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SerialModbusMaster	KEYWORD1	SerialModbusMaster
-SerialModbusSlave	KEYWORD1	SerialModbusSlave
-MBData_t	KEYWORD1	MBData_t
-MBFunctionCode_t	KEYWORD1	MBFunctionCode_t
-MBSubFunctionCode_t	KEYWORD1	MBSubFunctionCode_t
-MBException_t	KEYWORD1	MBException_t
-MBStatus_t	KEYWORD1	MBStatus_t
+SerialModbusMaster	KEYWORD1
+SerialModbusSlave	KEYWORD1
+MBData_t	KEYWORD1
+MBFunctionCode_t	KEYWORD1
+MBSubFunctionCode_t	KEYWORD1
+MBException_t	KEYWORD1
+MBStatus_t	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language/Libraries Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format